### PR TITLE
bug(bucket_list): utilise sequence to enforce uniqueness

### DIFF
--- a/spec/factories/bucket_lists.rb
+++ b/spec/factories/bucket_lists.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :bucket_list do
-    name { Faker::Name.title }
+    sequence(:name) { |n| "#{Faker::Name.title} #{n}" }
     user nil
   end
 end


### PR DESCRIPTION
Enforce bucket list name uniqueness in the corresponding factory.